### PR TITLE
Fixes #64

### DIFF
--- a/metalog/metaListener.go
+++ b/metalog/metaListener.go
@@ -97,7 +97,9 @@ func (m *jobLogMetaListener) Start(params *logMetaListenerParams, wg *sync.WaitG
 				log.Trace().Msg("Stop child process because job is ended.")
 
 				// delete metalog results over limit
-				m.MetaLog.Results = m.MetaLog.Results[:jobResultCount]
+				if len(m.MetaLog.Results) > jobResultCount {
+					m.MetaLog.Results = m.MetaLog.Results[:jobResultCount]
+				}
 
 				m.Mutex.Unlock()
 				goto shutdown


### PR DESCRIPTION
metalog discard old log not checking meta log length > minLogLength